### PR TITLE
add types for solvers

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -10,3 +10,10 @@ Depth = 3
 ```@meta
 CurrentModule = RangeEnclosures
 ```
+
+```@docs
+NaturalEnclosure
+MooreSkelboeEnclosure
+SumOfSquaresEnclosure
+TaylorModelsEnclosure
+```

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -13,6 +13,7 @@ const available_solvers = [:IntervalArithmetic,
 
 const optional_solvers = [:AffineArithmetic, :IntervalOptimisation, :SumOfSquares]
 
+include("algorithms.jl")
 include("intervals.jl")
 include("taylormodels.jl")
 include("branchandbound.jl")

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -33,6 +33,7 @@ API
 =================#
 include("enclose.jl")
 
-export enclose
+export enclose,
+  NaturalEnclosure, MooreSkelboeEnclosure, SumOfSquaresEnclosure, TaylorModelsEnclosure
 
 end # module

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -39,7 +39,7 @@ end
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
 Data type to compute the range of `f` over `X` using Taylor models.
-See `TaylorModels.jl` for more details.
+See [`TaylorModels.jl`](https://github.com/JuliaIntervals/TaylorModels.jl) for more details.
 
 ### Fields
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,0 +1,78 @@
+abstract type AbstractEnclosureAlgorithm end
+
+"""
+    $(TYPE)
+
+Data structure to compute the range of `f` over `X` using natural enclosure, that is simply
+evaluates `f(X)` using interval arithmetic.
+"""
+struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
+
+"""
+    $(TYPE)
+
+Data structure to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
+computes rigorously the global minimum and maximum of the function.
+See `IntervalOptimisation.jl` for more details.
+
+### Fields
+
+- `structure` -- (default: `HeapedVector`) the way in which vector elements
+                 are kept arranged; possible options are `HeapedVector` and `SortedVector`
+- `tol`       -- (default `1e-3`) tolerance to which the optima are computed
+
+### Notes
+
+To use this algorithm, you need to import `IntervalOptimisation.jl`
+"""
+struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
+    structure::T
+    tol::Float64
+end
+
+"""
+    $(TYPE)
+
+Data structure to compute the range of `f` over `X` using taylor models.
+See `TaylorModels.jl` for more details.
+
+### Fields
+
+- `order`     -- (default: `10`) order of the taylor model used to compute
+                 an enclosure of `f` over `dom`
+- `normalize` -- (default: `true`) if `true`, normalize the taylor model
+                 on the unit symmetric box around the origin
+
+"""
+struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
+    order::Int
+    normalize::Bool
+end
+
+"""
+    $(TYPE)
+
+Data structure to compute the range of `f` over `X` using the sum of squares algorithm.
+See `SumOfSquares.jl` for more details
+
+### Fields
+- `backend` -- backend used to solve the optimization problem, a list of available backends
+             can be found at
+- `order` -- (default `5`), maximum degree of the SDP relaxation
+- `quiet` -- (default `false`), I don't know what this is
+
+### Notes
+
+To use this solver you need to import `SumOfSquares.jl` and a backend.
+Since the optimization problem is solved numerically and not with interval arithmetic, the
+result of this algorithm is not rigorous.
+"""
+struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
+    backend::T
+    order::Int
+    quiet::Bool
+end
+
+function SumOfSquaresEnclosure(backend; order=5, quiet=false)
+    return SumOfSquaresEnclosure(backend, order, quiet)
+end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -59,7 +59,6 @@ See `SumOfSquares.jl` for more details
 - `backend` -- backend used to solve the optimization problem; a list of available backends
              can be found [here](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers)
 - `order` -- (default `5`), maximum degree of the SDP relaxation
-- `quiet` -- (default `false`), I don't know what this is
 
 ### Notes
 
@@ -70,9 +69,8 @@ result of this algorithm is not rigorous.
 struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
     backend::T
     order::Int
-    quiet::Bool
 end
 
-function SumOfSquaresEnclosure(backend; order=5, quiet=false)
-    return SumOfSquaresEnclosure(backend, order, quiet)
+function SumOfSquaresEnclosure(backend; order=5)
+    return SumOfSquaresEnclosure(backend, order)
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -56,8 +56,8 @@ Data structure to compute the range of `f` over `X` using the sum-of-squares alg
 See `SumOfSquares.jl` for more details
 
 ### Fields
-- `backend` -- backend used to solve the optimization problem, a list of available backends
-             can be found at
+- `backend` -- backend used to solve the optimization problem; a list of available backends
+             can be found [here](TODO)
 - `order` -- (default `5`), maximum degree of the SDP relaxation
 - `quiet` -- (default `false`), I don't know what this is
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,8 +3,8 @@ abstract type AbstractEnclosureAlgorithm end
 """
    NaturalEnclosure <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using natural enclosure, that is simply
-evaluates `f(X)` using interval arithmetic.
+Data type to compute the range of `f` over `X` using natural enclosure, i.e., to
+evaluate `f(X)` with interval arithmetic.
 """
 struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 
@@ -12,7 +12,7 @@ struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
     MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
 
 Data type to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
-computes rigorously the global minimum and maximum of the function.
+rigorously computes the global minimum and maximum of the function.
 See [`IntervalOptimisation.jl`](https://github.com/JuliaIntervals/IntervalOptimisation.jl) for more details.
 
 ### Fields
@@ -57,13 +57,14 @@ Data type to compute the range of `f` over `X` using sum-of-squares optimization
 See [`SumOfSquares.jl`](https://github.com/jump-dev/SumOfSquares.jl) for more details
 
 ### Fields
+
 - `backend` -- backend used to solve the optimization problem; a list of available backends
              can be found [here](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers)
 - `order` -- (default `5`), maximum degree of the SDP relaxation
 
 ### Notes
 
-To use this solver you need to import `SumOfSquares.jl` and a backend.
+To use this solver, you need to import `SumOfSquares.jl` and a backend.
 Since the optimization problem is solved numerically and not with interval arithmetic, the
 result of this algorithm is not rigorous.
 """

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -61,7 +61,7 @@ TaylorModelsEnclosure(; order=10, normalize=true) = TaylorModelsEnclosure(order,
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
 Data type to compute the range of `f` over `X` using sum-of-squares optimization.
-See `SumOfSquares.jl` for more details
+See [`SumOfSquares.jl`](https://github.com/jump-dev/SumOfSquares.jl) for more details
 
 ### Fields
 - `backend` -- backend used to solve the optimization problem; a list of available backends

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -30,6 +30,11 @@ struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
     tol::Float64
 end
 
+function MooreSkelboeEnclosure(; structure=HeapedVector, tol=1e-3)
+    return MooreSkelboeEnclosure(structure, tol)
+end
+
+
 """
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
@@ -48,6 +53,9 @@ struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
     order::Int
     normalize::Bool
 end
+
+TaylorModelsEnclosure(; order=10, normalize=true) = TaylorModelsEnclosure(order, normalize)
+
 
 """
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -52,7 +52,7 @@ end
 """
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using the sum of squares algorithm.
+Data structure to compute the range of `f` over `X` using the sum-of-squares algorithm.
 See `SumOfSquares.jl` for more details
 
 ### Fields

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -60,7 +60,7 @@ TaylorModelsEnclosure(; order=10, normalize=true) = TaylorModelsEnclosure(order,
 """
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using the sum-of-squares algorithm.
+Data type to compute the range of `f` over `X` using sum-of-squares optimization.
 See `SumOfSquares.jl` for more details
 
 ### Fields

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,7 +3,7 @@ abstract type AbstractEnclosureAlgorithm end
 """
    NaturalEnclosure <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using natural enclosure, i.e., to
+Data type to bound the range of `f` over `X` using natural enclosure, i.e., to
 evaluate `f(X)` with interval arithmetic.
 """
 struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
@@ -11,7 +11,7 @@ struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 """
     MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
+Data type to bound the range of `f` over `X` using the Moore-Skelboe algorithm, which
 rigorously computes the global minimum and maximum of the function.
 See [`IntervalOptimisation.jl`](https://github.com/JuliaIntervals/IntervalOptimisation.jl) for more details.
 
@@ -33,7 +33,7 @@ end
 """
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using Taylor models.
+Data type to bound the range of `f` over `X` using Taylor models.
 See [`TaylorModels.jl`](https://github.com/JuliaIntervals/TaylorModels.jl) for more details.
 
 ### Fields
@@ -53,7 +53,7 @@ end
 """
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data type to compute the range of `f` over `X` using sum-of-squares optimization.
+Data type to bound the range of `f` over `X` using sum-of-squares optimization.
 See [`SumOfSquares.jl`](https://github.com/jump-dev/SumOfSquares.jl) for more details
 
 ### Fields

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -13,7 +13,7 @@ struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 
 Data type to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
 computes rigorously the global minimum and maximum of the function.
-See `IntervalOptimisation.jl` for more details.
+See [`IntervalOptimisation.jl`](https://github.com/JuliaIntervals/IntervalOptimisation.jl) for more details.
 
 ### Fields
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,7 +1,7 @@
 abstract type AbstractEnclosureAlgorithm end
 
 """
-    $(TYPE)
+   NaturalEnclosure <: AbstractEnclosureAlgorithm
 
 Data structure to compute the range of `f` over `X` using natural enclosure, that is simply
 evaluates `f(X)` using interval arithmetic.
@@ -9,7 +9,7 @@ evaluates `f(X)` using interval arithmetic.
 struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 
 """
-    $(TYPE)
+    MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
 
 Data structure to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
 computes rigorously the global minimum and maximum of the function.
@@ -31,7 +31,7 @@ struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
 end
 
 """
-    $(TYPE)
+    TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
 Data structure to compute the range of `f` over `X` using taylor models.
 See `TaylorModels.jl` for more details.
@@ -50,7 +50,7 @@ struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 end
 
 """
-    $(TYPE)
+    SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
 Data structure to compute the range of `f` over `X` using the sum of squares algorithm.
 See `SumOfSquares.jl` for more details

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -33,7 +33,7 @@ end
 """
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using taylor models.
+Data structure to compute the range of `f` over `X` using Taylor models.
 See `TaylorModels.jl` for more details.
 
 ### Fields

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -38,7 +38,7 @@ See `TaylorModels.jl` for more details.
 
 ### Fields
 
-- `order`     -- (default: `10`) order of the taylor model used to compute
+- `order`     -- (default: `10`) order of the Taylor model used to compute
                  an enclosure of `f` over `dom`
 - `normalize` -- (default: `true`) if `true`, normalize the Taylor model
                  on the unit symmetric box around the origin

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -25,15 +25,10 @@ See [`IntervalOptimisation.jl`](https://github.com/JuliaIntervals/IntervalOptimi
 
 To use this algorithm, you need to import `IntervalOptimisation.jl`
 """
-struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
-    structure::T
-    tol::Float64
+Base.@kwdef struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
+    structure::T = HeapedVector
+    tol::Float64 = 1e-3
 end
-
-function MooreSkelboeEnclosure(; structure=HeapedVector, tol=1e-3)
-    return MooreSkelboeEnclosure(structure, tol)
-end
-
 
 """
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
@@ -49,12 +44,10 @@ See [`TaylorModels.jl`](https://github.com/JuliaIntervals/TaylorModels.jl) for m
                  on the unit symmetric box around the origin
 
 """
-struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
-    order::Int
-    normalize::Bool
+Base.@kwdef struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
+    order::Int = 10
+    normalize::Bool = true
 end
-
-TaylorModelsEnclosure(; order=10, normalize=true) = TaylorModelsEnclosure(order, normalize)
 
 
 """
@@ -74,11 +67,7 @@ To use this solver you need to import `SumOfSquares.jl` and a backend.
 Since the optimization problem is solved numerically and not with interval arithmetic, the
 result of this algorithm is not rigorous.
 """
-struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
+Base.@kwdef struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
     backend::T
-    order::Int
-end
-
-function SumOfSquaresEnclosure(backend; order=5)
-    return SumOfSquaresEnclosure(backend, order)
+    order::Int = 5
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,7 +3,7 @@ abstract type AbstractEnclosureAlgorithm end
 """
    NaturalEnclosure <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using natural enclosure, that is simply
+Data type to compute the range of `f` over `X` using natural enclosure, that is simply
 evaluates `f(X)` using interval arithmetic.
 """
 struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
@@ -11,7 +11,7 @@ struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 """
     MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
+Data type to compute the range of `f` over `X` using the Moore-Skelboe algorithm, which
 computes rigorously the global minimum and maximum of the function.
 See `IntervalOptimisation.jl` for more details.
 
@@ -33,14 +33,14 @@ end
 """
     TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using Taylor models.
+Data type to compute the range of `f` over `X` using Taylor models.
 See `TaylorModels.jl` for more details.
 
 ### Fields
 
 - `order`     -- (default: `10`) order of the taylor model used to compute
                  an enclosure of `f` over `dom`
-- `normalize` -- (default: `true`) if `true`, normalize the taylor model
+- `normalize` -- (default: `true`) if `true`, normalize the Taylor model
                  on the unit symmetric box around the origin
 
 """
@@ -52,12 +52,12 @@ end
 """
     SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
 
-Data structure to compute the range of `f` over `X` using the sum-of-squares algorithm.
+Data type to compute the range of `f` over `X` using the sum-of-squares algorithm.
 See `SumOfSquares.jl` for more details
 
 ### Fields
 - `backend` -- backend used to solve the optimization problem; a list of available backends
-             can be found [here](TODO)
+             can be found [here](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers)
 - `order` -- (default `5`), maximum degree of the SDP relaxation
 - `quiet` -- (default `false`), I don't know what this is
 


### PR DESCRIPTION
@mforets @schillic this is the first step for the API restructure 🛠️ 

First, I added the types and we can have a first round of comments on names, fields etc.

Next, we can restructure the `enclose` function using multiple dispatch instead of branches (other here on in separate PR)

A couple of notes
- `BranchAndBound` is missing atm because the current code (which for some reason has TaylorModels hard-coded) is to be rewritten using the prototype I showed last time, so I thought it's easier to leave it out for now
- `AffineArithmetic` is to be removed since, as discussed in zulip, hence no type for that
- The `SumOfSquares` has a `quiet` field (?) but I don't know what that is, nor whether it should be there.