### PR TITLE
use type dispatch for enclose

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -23,15 +23,6 @@ enclose
 relative_precision
 ```
 
-## Enclosure methods
-
-```@docs
-enclose_IntervalArithmetic
-enclose_IntervalOptimisation
-enclose_TaylorModels
-enclose_SumOfSquares
-```
-
 ## Specifics to sum-of-squares optimization
 
 ```@docs

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -12,7 +12,7 @@ CurrentModule = RangeEnclosures
 ```
 
 ```@docs
-AbstractRangeEnclosure
+AbstractEnclosureAlgorithm
 NaturalEnclosure
 MooreSkelboeEnclosure
 SumOfSquaresEnclosure

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -12,6 +12,7 @@ CurrentModule = RangeEnclosures
 ```
 
 ```@docs
+AbstractRangeEnclosure
 NaturalEnclosure
 MooreSkelboeEnclosure
 SumOfSquaresEnclosure

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -25,8 +25,7 @@ API
 include("enclose.jl")
 
 export enclose,
-  NaturalEnclosure, MooreSkelboeEnclosure, SumOfSquaresEnclosure, TaylorModelsEnclosure
+  NaturalEnclosure, MooreSkelboeEnclosure, SumOfSquaresEnclosure, TaylorModelsEnclosure,
+  AbstractEnclosureAlgorithm
 
-const available_solvers = (NaturalEnclosure, MooreSkelboeEnclosure,
-                           SumOfSquaresEnclosure, TaylorModelsEnclosure)
 end # module

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -27,4 +27,6 @@ include("enclose.jl")
 export enclose,
   NaturalEnclosure, MooreSkelboeEnclosure, SumOfSquaresEnclosure, TaylorModelsEnclosure
 
+const available_solvers = (NaturalEnclosure, MooreSkelboeEnclosure,
+                           SumOfSquaresEnclosure, TaylorModelsEnclosure)
 end # module

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -4,14 +4,6 @@ using DynamicPolynomials, Requires, Reexport
 @reexport using IntervalArithmetic
 const Interval_or_IntervalBox = Union{Interval, IntervalBox}
 
-#=================
-Available methods
-==================#
-const available_solvers = [:IntervalArithmetic,
-                           :TaylorModels,
-                           :BranchandBound]
-
-const optional_solvers = [:IntervalOptimisation, :SumOfSquares]
 
 include("algorithms.jl")
 include("intervals.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -42,7 +42,7 @@ To use this algorithm, you need to import `IntervalOptimisation.jl`
 ```jldoctest
 julia> using IntervalOptimisation
 
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, MooreSkelboeEnclosure()) # default values
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, MooreSkelboeEnclosure()) # default parameters
 [0.916034, 1.00213]
 
 julia> enclose(x -> 1 - x^4 + x^5, 0..1, MooreSkelboeEnclosure(; tol=1e-2))
@@ -69,7 +69,7 @@ See [`TaylorModels.jl`](https://github.com/JuliaIntervals/TaylorModels.jl) for m
 ### Examples
 
 ```jldoctest
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure()) # default values
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure()) # default parameters
 [0.8125, 1.09375]
 
 julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure(; order=4))

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -5,6 +5,13 @@ abstract type AbstractEnclosureAlgorithm end
 
 Data type to bound the range of `f` over `X` using natural enclosure, i.e., to
 evaluate `f(X)` with interval arithmetic.
+
+### Examples
+
+```jldoctest
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, NaturalEnclosure())
+[0, 2]
+```
 """
 struct NaturalEnclosure <: AbstractEnclosureAlgorithm end
 
@@ -24,6 +31,17 @@ See [`IntervalOptimisation.jl`](https://github.com/JuliaIntervals/IntervalOptimi
 ### Notes
 
 To use this algorithm, you need to import `IntervalOptimisation.jl`
+
+### Examples
+
+```jldoctest
+julia> using IntervalOptimisation
+
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, MooreSkelboeEnclosure()) # default values
+[0.916034, 1.00213]
+
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, MooreSkelboeEnclosure(; tol=1e-2))
+[0.900812, 1.0326]
 """
 Base.@kwdef struct MooreSkelboeEnclosure{T} <: AbstractEnclosureAlgorithm
     structure::T = HeapedVector
@@ -43,6 +61,16 @@ See [`TaylorModels.jl`](https://github.com/JuliaIntervals/TaylorModels.jl) for m
 - `normalize` -- (default: `true`) if `true`, normalize the Taylor model
                  on the unit symmetric box around the origin
 
+### Examples
+
+```jldoctest
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure()) # default values
+[0.8125, 1.09375]
+
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure(; order=4))
+[0.78125, 1.125]
+
+```
 """
 Base.@kwdef struct TaylorModelsEnclosure <: AbstractEnclosureAlgorithm
     order::Int = 10
@@ -67,6 +95,23 @@ See [`SumOfSquares.jl`](https://github.com/jump-dev/SumOfSquares.jl) for more de
 To use this solver, you need to import `SumOfSquares.jl` and a backend.
 Since the optimization problem is solved numerically and not with interval arithmetic, the
 result of this algorithm is not rigorous.
+
+```julia
+julia> using SumOfSquares, SDPA
+
+julia> backend = SDPA.Optimizer
+
+julia> enclose(x -> -x^3/6 + 5x, 1..4, SumOfSquaresEnclosure(; backend=backend))
+[4.8333, 10.541]
+```
+
+You can also pass additional keyword arguments that will be passed to the SOSMOdel, e.g. to
+print in non-verbose mode
+
+```julia
+julia> enclose(x -> -x^3/6 + 5x, 1..4, SumOfSquaresEnclosure(; backend=backend); QUIET=true)
+[4.8333, 10.541]
+```
 """
 Base.@kwdef struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
     backend::T

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,3 +1,8 @@
+"""
+    AbstractEnclosureAlgorithm
+
+Abstract type for range enclosure algorithms.
+"""
 abstract type AbstractEnclosureAlgorithm end
 
 """

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -109,14 +109,6 @@ julia> backend = SDPA.Optimizer
 julia> enclose(x -> -x^3/6 + 5x, 1..4, SumOfSquaresEnclosure(; backend=backend))
 [4.8333, 10.541]
 ```
-
-You can also pass additional keyword arguments that will be passed to the `SOSModel`, e.g. to
-print in non-verbose mode
-
-```julia
-julia> enclose(x -> -x^3/6 + 5x, 1..4, SumOfSquaresEnclosure(; backend=backend); QUIET=true)
-[4.8333, 10.541]
-```
 """
 Base.@kwdef struct SumOfSquaresEnclosure{T} <: AbstractEnclosureAlgorithm
     backend::T

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -110,7 +110,7 @@ julia> enclose(x -> -x^3/6 + 5x, 1..4, SumOfSquaresEnclosure(; backend=backend))
 [4.8333, 10.541]
 ```
 
-You can also pass additional keyword arguments that will be passed to the SOSMOdel, e.g. to
+You can also pass additional keyword arguments that will be passed to the `SOSModel`, e.g. to
 print in non-verbose mode
 
 ```julia

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -54,6 +54,11 @@ julia> enclose(x -> 1 - x^4 + x^5, 0..1, [:TaylorModels, :IntervalArithmetic])
 [0.8125, 1.09375]
 ```
 """
+function enclose(f::Function, dom::Interval_or_IntervalBox,
+                 solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
+    return _enclose(solver, f, dom; kwargs)
+end
+
 function enclose(f::Function, dom::Interval_or_IntervalBox, solver::Symbol; kwargs...)
 
     𝑂 = Dict(kwargs)

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -1,16 +1,15 @@
 """
-    enclose(f::Function, dom::Interval_or_IntervalBox,
-            solver::Symbol=:IntervalArithmetic; [kwargs]...)
+    enclose(f, dom[, solver=NaturalEnclosure()]; kwargs...)
 
 Return a range enclosure of a univariate or multivariate function on the given
 domain.
 
 ### Input
 
-- `f`      -- function
+- `f`      -- function or `AbstractPolynomialLike` object
 - `dom`    -- hyperrectangular domain, either a unidimensional  `Interval` or
               a multidimensional `IntervalBox`
-- `solver` -- (optional, default: `IntervalArithmetic`) choose one among the
+- `solver` -- (optional, default: `NaturalEnclosure()`) choose one among the
               available solvers; see `RangeEnclosures.available_solvers` for the
               full list
 - `kwargs` -- optional keyword arguments passed to the solver; for available
@@ -18,40 +17,25 @@ domain.
 
 ### Output
 
-An interval representing the range enclosure (minimum and maximum) of `f` over
-its domain `dom`.
+An interval enclosure of the range of `f` over `dom`.
 
 ### Examples
 
 ```jldoctest enclose_examples
-julia> using RangeEnclosures, IntervalOptimisation
-
 julia> enclose(x -> 1 - x^4 + x^5, 0..1) # use default solver
 [0, 2]
 
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, :IntervalArithmetic)
-[0, 2]
-
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, :TaylorModels, order=4)
-[0.78125, 1.125]
-
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, :TaylorModels, order=10)
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, TaylorModelsEnclosure())
 [0.8125, 1.09375]
-
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, :IntervalOptimisation)
-[0.916034, 1.00213]
 ```
-You can also try other solvers such as `SumOfSquares` and `AffineArithmetic`.
 
 A vector of solvers can be passed in the `solver` options. Then, the result is
 obtained by intersecting the range enclosure of each solver.
-In the previous example,
 
 ```jldoctest enclose_examples
-julia> using RangeEnclosures
-
-julia> enclose(x -> 1 - x^4 + x^5, 0..1, [:TaylorModels, :IntervalArithmetic])
+julia> enclose(x -> 1 - x^4 + x^5, 0..1, [TaylorModelsEnclosure(), NaturalEnclosure()])
 [0.8125, 1.09375]
+
 ```
 """
 function enclose(f::Function, dom::Interval_or_IntervalBox,

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -40,7 +40,7 @@ julia> enclose(x -> 1 - x^4 + x^5, 0..1, [TaylorModelsEnclosure(), NaturalEnclos
 """
 function enclose(f::Function, dom::Interval_or_IntervalBox,
                  solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
-    return _enclose(solver, f, dom; kwargs)
+    return _enclose(solver, f, dom; kwargs...)
 end
 
 function enclose(f::Function, dom::Interval_or_IntervalBox, solver::Symbol; kwargs...)
@@ -62,12 +62,12 @@ end
 function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalBox,
                  solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
     f(x...) = p(variables(p) => x)
-    return enclose(f, dom, solver; kwargs...)
+    return _enclose(solver, f, dom; kwargs...)
 end
 
 function enclose(f::Function, dom::Interval_or_IntervalBox,
                  method::Vector; kwargs...)
-   return mapreduce(ξ -> enclose(f, dom, ξ, kwargs...), ∩, method)
+   return mapreduce(ξ -> _enclose(ξ, f, dom; kwargs...), ∩, method)
 end
 
 """

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -10,8 +10,8 @@ domain.
 - `dom`    -- hyperrectangular domain, either a unidimensional  `Interval` or
               a multidimensional `IntervalBox`
 - `solver` -- (optional, default: `NaturalEnclosure()`) choose one among the
-              available solvers; see `RangeEnclosures.available_solvers` for the
-              full list
+              available solvers; you can get a list of available solvers with
+              `subtypes(AbstractEnclosureAlgorithm)`
 - `kwargs` -- optional keyword arguments passed to the solver; for available
               options see the documentation of each solver
 

--- a/src/intervaloptimisation.jl
+++ b/src/intervaloptimisation.jl
@@ -31,7 +31,8 @@ The solver finds the global minimum  and maximum of the function `f` over the `I
 We refer to the documentation and source code of `IntervalOptimisation` for details
 on the implemented methods.
 """
-function enclose(f::Function, dom::Interval_or_IntervalBox, mse::MooreSkelboeEnclosure)
+function _enclose(mse::MooreSkelboeEnclosure, f::Function, dom::Interval_or_IntervalBox;
+                  kwargs...)
 
     global_min, _ = minimise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)
     global_max, _ = maximise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)

--- a/src/intervaloptimisation.jl
+++ b/src/intervaloptimisation.jl
@@ -31,11 +31,10 @@ The solver finds the global minimum  and maximum of the function `f` over the `I
 We refer to the documentation and source code of `IntervalOptimisation` for details
 on the implemented methods.
 """
-function enclose_IntervalOptimisation(f::Function, dom::Interval_or_IntervalBox;
-                                      structure=HeapedVector, tol=1e-3)
+function enclose(f::Function, dom::Interval_or_IntervalBox, mse::MooreSkelboeEnclosure)
 
-    global_min, _ = minimise(X->f(X...), dom, structure=structure, tol=tol)
-    global_max, _ = maximise(X->f(X...), dom, structure=structure, tol=tol)
+    global_min, _ = minimise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)
+    global_max, _ = maximise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)
 
     return Interval(inf(global_min), sup(global_max))
 end

--- a/src/intervaloptimisation.jl
+++ b/src/intervaloptimisation.jl
@@ -3,34 +3,6 @@ Methods using Interval Optimisation
 ===================================#
 using .IntervalOptimisation
 
-"""
-    enclose_IntervalOptimisation(f::Function, dom::Interval_or_IntervalBox;
-                                 structure=HeapedVector, tol=1e-3)
-
-Compute a range enclosure using interval optimisation.
-
-### Input
-
-- `f`         -- function
-- `dom`       -- hyperrectangular domain, either a unidimensional  `Interval` or
-                 a multidimensional `IntervalBox`
-- `structure` -- (optional, default: `HeapedVector`) the way in which vector elements
-                 are kept arranged; possible options are `HeapedVector` and `SortedVector`
-- `tol`       -- tolerance to which the optima are computed
-
-### Output
-
-An interval representing the range enclosure (minimum and maximum) of `f` over
-its domain `dom`.
-
-### Algorithm
-
-The solver finds the global minimum  and maximum of the function `f` over the `Interval` or
-`IntervalBox` `dom` using the Moore-Skelboe algorithm.
-
-We refer to the documentation and source code of `IntervalOptimisation` for details
-on the implemented methods.
-"""
 function _enclose(mse::MooreSkelboeEnclosure, f::Function, dom::Interval_or_IntervalBox;
                   kwargs...)
 

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -26,6 +26,6 @@ application of the rules of interval arithmetic.
 
 We refer to the documentation and source code of `IntervalArithmetic` for details.
 """
-function enclose_IntervalArithmetic(f::Function, dom::Interval_or_IntervalBox)
+function enclose(f::Function, dom::Interval_or_IntervalBox, ::NaturalEnclosure)
     return f(dom...)
 end

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -26,6 +26,6 @@ application of the rules of interval arithmetic.
 
 We refer to the documentation and source code of `IntervalArithmetic` for details.
 """
-function enclose(f::Function, dom::Interval_or_IntervalBox, ::NaturalEnclosure)
+function _enclose(::NaturalEnclosure, f::Function, dom::Interval_or_IntervalBox; kwargs...)
     return f(dom...)
 end

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -1,31 +1,7 @@
 #=================================
 Methods using Interval Arithmetic
 =================================#
-using IntervalArithmetic
 
-"""
-    enclose_IntervalArithmetic(f::Function, dom::Interval_or_IntervalBox)
-
-Compute a range enclosure using interval arithmetic substitution.
-
-### Input
-
-- `f`   -- function
-- `dom` -- hyperrectangular domain, either a unidimensional  `Interval` or
-           a multidimensional `IntervalBox`
-
-### Output
-
-An interval representing the range enclosure (minimum and maximum) of `f` over
-its domain `dom`.
-
-### Algorithm
-
-The result is obtained by substitution of `dom` on the function `f` and
-application of the rules of interval arithmetic.
-
-We refer to the documentation and source code of `IntervalArithmetic` for details.
-"""
 function _enclose(::NaturalEnclosure, f::Function, dom::Interval_or_IntervalBox; kwargs...)
     return f(dom...)
 end

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -82,9 +82,10 @@ julia> enclose_SumOfSquares(f, dom, order; backend=backend, QUIET=true)
 
 To get the runtime, use `MOI.get(model, MOI.SolveTime())`.
 """
-function enclose_SumOfSquares(f::Function, dom::Interval_or_IntervalBox;
-                              backend, order::Int=5, kwargs...)
-    _enclose_SumOfSquares(f, dom, order, backend; kwargs...)
+function enclose(f::Function, dom::Interval_or_IntervalBox,
+                            sose::SumOfSquaresEnclosure; kwargs...)
+
+    _enclose_SumOfSquares(f, dom, sose.order, sose.backend; kwargs...)
 end
 
 function _enclose_SumOfSquares(f::Function, dom::Interval, order::Int,

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -83,7 +83,7 @@ julia> enclose_SumOfSquares(f, dom, order; backend=backend, QUIET=true)
 To get the runtime, use `MOI.get(model, MOI.SolveTime())`.
 """
 function enclose(f::Function, dom::Interval_or_IntervalBox,
-                            sose::SumOfSquaresEnclosure; kwargs...)
+                 sose::SumOfSquaresEnclosure; kwargs...)
 
     _enclose_SumOfSquares(f, dom, sose.order, sose.backend; kwargs...)
 end

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -28,60 +28,7 @@ An instance of `SOSModel` for the given backend and options.
     end
 end
 
-"""
-    enclose_SumOfSquares(f::Function, dom::Interval_or_IntervalBox; backend,
-                         order::Int=5, kwargs...)
 
-Compute a range enclosure using sum-of-squares optimization.
-
-### Input
-
-- `f`       -- function
-- `dom`     -- hyperrectangular domain, either a unidimensional `Interval` or
-               a multidimensional `IntervalBox`
-- `backend` -- the optimization backend (aka JuMP solver)
-- `order`   -- (optional, default: `5`) maximum degree of the SDP relaxation
-- `kwargs`  -- additional keyword arguments
-
-### Output
-
-An interval representing the range enclosure (minimum and maximum) of `f` over
-its domain `dom`.
-
-### Algorithm
-
-The range enclosure is computed using polynomial optimization methods.
-We refer to the documentation and examples of `SumOfSquares.jl` for details.
-
-### Notes
-
-You need to import and pass an SDP solver as the `backend` parameter. A list of SDP solvers
-can be found [here](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers).
-
-For instance, to use `SDPA`, use it as:
-
-```julia
-julia > using SDPA
-
-julia> backend = SDPA.Optimizer
-
-julia> enclose_SumOfSquares(f, dom, order; backend=backend)
-...
-```
-
-To use `MOSEK` in non-verbose mode, let
-
-```julia
-julia> using MosekTools
-
-julia> backend = MosekTools.Mosek.Optimizer;
-
-julia> enclose_SumOfSquares(f, dom, order; backend=backend, QUIET=true)
-...
-```
-
-To get the runtime, use `MOI.get(model, MOI.SolveTime())`.
-"""
 function _enclose(sose::SumOfSquaresEnclosure, f::Function, dom::Interval_or_IntervalBox;
                   kwargs...)
 

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -82,8 +82,8 @@ julia> enclose_SumOfSquares(f, dom, order; backend=backend, QUIET=true)
 
 To get the runtime, use `MOI.get(model, MOI.SolveTime())`.
 """
-function enclose(f::Function, dom::Interval_or_IntervalBox,
-                 sose::SumOfSquaresEnclosure; kwargs...)
+function _enclose(sose::SumOfSquaresEnclosure, f::Function, dom::Interval_or_IntervalBox;
+                  kwargs...)
 
     _enclose_SumOfSquares(f, dom, sose.order, sose.backend; kwargs...)
 end

--- a/src/taylormodels.jl
+++ b/src/taylormodels.jl
@@ -35,12 +35,12 @@ symmetric ``[-1..1]^n`` domain.
 
 We refer to the documentation and source code of `TaylorModels` for details.
 """
-function enclose_TaylorModels(f::Function, dom::Interval_or_IntervalBox;
-                              order::Int=10, normalize::Bool=true)
-    if normalize
-        R = _enclose_TaylorModels_norm(f, dom, order)
+function enclose(f::Function, dom::Interval_or_IntervalBox, tme::TaylorModelsEnclosure)
+
+    if tme.normalize
+        R = _enclose_TaylorModels_norm(f, dom, tme.order)
     else
-        R = _enclose_TaylorModels(f, dom, order)
+        R = _enclose_TaylorModels(f, dom, tme.order)
     end
     return R
 end

--- a/src/taylormodels.jl
+++ b/src/taylormodels.jl
@@ -6,35 +6,7 @@ using TaylorModels
 @inline zeroBox(N) = IntervalBox(0..0, N)
 @inline symBox(N) = IntervalBox(-1..1, N)
 
-"""
-    enclose_TaylorModels(f::Function, dom::Interval_or_IntervalBox;
-                         order::Int=10, normalize::Bool=true)
 
-Compute a range enclosure using Taylor Models substitution.
-
-### Input
-
-- `f`         -- function
-- `dom`       -- hyperrectangular domain, either a unidimensional  `Interval` or
-                 a multidimensional `IntervalBox`
-- `order`     -- (optional, default: `10`) order of the taylor model used to compute
-                 an enclosure of `f` over `dom`
-- `normalize` -- (optional, default: `true`) if `true`, normalize the taylor model
-                 on the unit symmetric box around the origin
-
-### Output
-
-An interval representing the range enclosure (minimum and maximum) of `f` over
-its domain `dom`.
-
-### Algorithm
-
-The result is obtained by an evaluation of the function over Taylor model variables
-after recentering in the given domain and (optionally) normalizing in the
-symmetric ``[-1..1]^n`` domain.
-
-We refer to the documentation and source code of `TaylorModels` for details.
-"""
 function _enclose(tme::TaylorModelsEnclosure, f::Function, dom::Interval_or_IntervalBox;
                   kwargs...)
 

--- a/src/taylormodels.jl
+++ b/src/taylormodels.jl
@@ -35,7 +35,8 @@ symmetric ``[-1..1]^n`` domain.
 
 We refer to the documentation and source code of `TaylorModels` for details.
 """
-function enclose(f::Function, dom::Interval_or_IntervalBox, tme::TaylorModelsEnclosure)
+function _enclose(tme::TaylorModelsEnclosure, f::Function, dom::Interval_or_IntervalBox;
+                  kwargs...)
 
     if tme.normalize
         R = _enclose_TaylorModels_norm(f, dom, tme.order)

--- a/test/multivariate.jl
+++ b/test/multivariate.jl
@@ -14,7 +14,7 @@ end
     g(x, y) = (x + 2y - 7)^2 + (2x + y - 5)^2
     dom = IntervalBox(-10..10, 2)
 
-    x = enclose(g, dom, :IntervalArithmetic)
+    x = enclose(g, dom, NaturalEnclosure())
     xref = Interval(0, 2594)
     r = relative_precision(x, xref)
     @test inf(r) ≤ 1e-5 && sup(r) ≤ 1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using RangeEnclosures: relative_precision
 
 using DynamicPolynomials: @polyvar
 
-available_solvers = (:IntervalArithmetic, :TaylorModels, :BranchandBound, :IntervalOptimisation)
+available_solvers = (NaturalEnclosure(), TaylorModelsEnclosure(), :BranchandBound, MooreSkelboeEnclosure())
 
 include("univariate.jl")
 include("multivariate.jl")

--- a/test/univariate.jl
+++ b/test/univariate.jl
@@ -7,10 +7,10 @@
     for solver in available_solvers
         x = enclose(f, dom, solver)
         r = relative_precision(x, xref)
-        if solver == :TaylorModels
+        if solver isa TaylorModelsEnclosure
             # for this example, TaylorModels cannot tightly approximate the lhs
             @test inf(r) ≤ 30 && sup(r) ≤ 1e-10
-        elseif solver == :SumOfSquares
+        elseif solver isa SumOfSquaresEnclosure
             # solver returns negative -1.06259e-06
             @test abs(inf(r)) ≤ 1e-5 && sup(r) ≤ 1e-5
         else
@@ -23,24 +23,24 @@ end
     f(x) = -x^3/6 + 5x
     dom = Interval(1, 4)
 
-    x = enclose(f, dom, :IntervalArithmetic)
+    x = enclose(f, dom, NaturalEnclosure())
     xref = Interval(-5.66667, 19.8334)
     r = relative_precision(x, xref)
     @test inf(r) ≤ 1e-5 && sup(r) ≤ 1e-5
 
-    x = enclose(f, dom, :TaylorModels, order=4)
+    x = enclose(f, dom, TaylorModelsEnclosure(order=4))
     xref = Interval(-4.2783, 12.7084)
     r = relative_precision(x, xref)
     @test inf(r) ≤ 1e-5 && sup(r) ≤ 1e-5
 
-    x = enclose(f, dom, :IntervalOptimisation)
+    x = enclose(f, dom, MooreSkelboeEnclosure())
     xref = Interval(4.83299, 10.5448)
     r = relative_precision(x, xref)
     @test inf(r) ≤ 1e-5 && sup(r) ≤ 1e-5
 
     if VERSION < v"1.7"
         using SumOfSquares, SDPA
-        x = enclose(f, dom, :SumOfSquares; backend=SDPA.Optimizer)
+        x = enclose(f, dom, SumOfSquaresEnclosure(backend=SDPA.Optimizer))
         xref = Interval(4.8333, 10.541)
         r = relative_precision(x, xref)
         @test inf(r) ≤ 1e-5 && sup(r) ≤ 1e-5


### PR DESCRIPTION
- use type dispatch in enclose 
- `BranchAndBound` still uses the old version with symbol, as that needs to be rewritten anway. We could either leave it like that or add a type for that too that mimics the current behavior and change later

### TODO

- [x] update docs. Currently each method of `enclose` has it's own docstring, I was thinking to remove those and have an usage example for each type (i.e. the types docstrings would replace the current several docstrings for each method) + have a general docstring for `enclose`