### PR TITLE
update multivariate functions API

### DIFF
--- a/src/branchandbound.jl
+++ b/src/branchandbound.jl
@@ -6,7 +6,7 @@
 end
 
 @inline function enclose(f::Function, X::IntervalBox, ba::BranchAndBoundEnclosure;
-                         df=t->ForwardDiff.gradient(w->f(w...), t.v))
+                         df=t->ForwardDiff.gradient(f, t.v))
     return _branch_bound(ba, f, X, df)
 end
 
@@ -18,7 +18,7 @@ function _branch_bound(ba::BranchAndBoundEnclosure, f::Function, X::Interval_or_
     range_extrema, flag = _monotonicity_check(f, X, dfX)
     flag && return hull(range_extrema, initial)
 
-    fX = f(X...)  # TODO: allow user to choose how to evaluate this (mean value, natural enclosure)
+    fX = f(X)  # TODO: allow user to choose how to evaluate this (mean value, natural enclosure)
     # if tolerance or maximum number of iteration is met, return current enclosure
     if diam(fX) <= ba.tol || cnt == ba.maxdepth
         return hull(fX, initial)
@@ -55,5 +55,5 @@ function _monotonicity_check(f::Function, X::IntervalBox{N}, ∇fX::AbstractVect
         end
     end
 
-    return hull(f(low...), f(high...)), true
+    return hull(f(low), f(high)), true
 end

--- a/src/intervaloptimisation.jl
+++ b/src/intervaloptimisation.jl
@@ -6,8 +6,8 @@ using .IntervalOptimisation
 function _enclose(mse::MooreSkelboeEnclosure, f::Function, dom::Interval_or_IntervalBox;
                   kwargs...)
 
-    global_min, _ = minimise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)
-    global_max, _ = maximise(X->f(X...), dom, structure=mse.structure, tol=mse.tol)
+    global_min, _ = minimise(f, dom, structure=mse.structure, tol=mse.tol)
+    global_max, _ = maximise(f, dom, structure=mse.structure, tol=mse.tol)
 
     return Interval(inf(global_min), sup(global_max))
 end

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -3,7 +3,7 @@ Methods using Interval Arithmetic
 =================================#
 
 function _enclose(::NaturalEnclosure, f::Function, dom::Interval_or_IntervalBox; kwargs...)
-    return f(dom...)
+    return f(dom)
 end
 
 function _enclose(::MeanValueEnclosure, f::Function, dom::Interval;
@@ -12,6 +12,6 @@ function _enclose(::MeanValueEnclosure, f::Function, dom::Interval;
 end
 
 function _enclose(::MeanValueEnclosure, f::Function, dom::IntervalBox;
-                  df=t->ForwardDiff.gradient(w->f(w...), t.v))
-    return f(mid.(dom)...) + dot(df(dom), dom - mid.(dom))
+                  df=t->ForwardDiff.gradient(f, t.v))
+    return f(mid.(dom)) + dot(df(dom), dom - mid.(dom))
 end

--- a/src/polynomials.jl
+++ b/src/polynomials.jl
@@ -2,7 +2,7 @@ using .MultivariatePolynomials
 
 function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalBox,
                  solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
-    f(x...) = p(variables(p) => x)
+    f(x) = p(x...)
     return _enclose(solver, f, dom; kwargs...)
 end
 

--- a/src/taylormodels.jl
+++ b/src/taylormodels.jl
@@ -39,7 +39,7 @@ function _enclose_TaylorModels(f::Function, dom::IntervalBox{N}, order::Int) whe
     x0 = mid(dom)
     set_variables(Float64, "x", order=2order, numvars=N)
     x = [TaylorModelN(i, order, IntervalBox(x0), dom) for i=1:N]
-    return evaluate(f(x...), dom - x0)
+    return evaluate(f(x), dom - x0)
 end
 
 # normalized multivariate
@@ -52,5 +52,5 @@ function _enclose_TaylorModels_norm(f::Function, dom::IntervalBox{N}, order::Int
     x = [TaylorModelN(i, order, IntervalBox(x0), dom) for i=1:N]
     xnorm = [normalize_taylor(xi.pol, dom - x0, true) for xi in x]
     xnormTM = [TaylorModelN(xi_norm, 0..0, zBoxN, sBoxN) for xi_norm in xnorm]
-    return evaluate(f(xnormTM...), sBoxN)
+    return evaluate(f(xnormTM), sBoxN)
 end

--- a/test/multivariate.jl
+++ b/test/multivariate.jl
@@ -1,6 +1,6 @@
 @testset "Multivariate functions" begin
     # himmilbeau from Daisy benchmarks
-    f(x1, x2, x3) = -x1*x2 - 2*x2*x3 - x1 - x3
+    f(x) = -x[1] * x[2] - 2 * x[2] * x[3] - x[1] - x[3]
     dom = Interval(-4.5, -0.3) × Interval(0.4, 0.9) × Interval(3.8, 7.8)
     xref = Interval(-20.786552979420335, -0.540012836551535) # MOSEK deg 6
     for solver in available_solvers
@@ -11,7 +11,7 @@
 end
 
 @testset "Multivariate example from the Quickstart Guide" begin
-    g(x, y) = (x + 2y - 7)^2 + (2x + y - 5)^2
+    g(x) = (x[1] + 2x[2] - 7)^2 + (2x[1] + x[2] - 5)^2
     dom = IntervalBox(-10..10, 2)
 
     x = enclose(g, dom, NaturalEnclosure())


### PR DESCRIPTION
This PR requires multivariate functions passed to `enclose` to take a single object as input. Fixes #75
I think after this PR the package can / should be released
