### PR TITLE
Outsource doctests to normal tests

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,2 @@
 [deps]
-AffineArithmetic = "2e89c364-fad6-56cb-99bd-ebadcd2cf8d2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
-IntervalOptimisation = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
-SDPA = "b9a10b5b-afa4-512f-a053-bb3d8080febc"
-SumOfSquares = "4b9e565b-77fc-50a5-a571-1244f986bda1"
-TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"

--- a/docs/init.jl
+++ b/docs/init.jl
@@ -1,0 +1,1 @@
+DocMeta.setdocmeta!(RangeEnclosures, :DocTestSetup, :(using RangeEnclosures); recursive=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
-using Documenter, RangeEnclosures, IntervalOptimisation, SumOfSquares, SDPA, TaylorModels
+using Documenter, RangeEnclosures
 
-DocMeta.setdocmeta!(RangeEnclosures, :DocTestSetup, :(using RangeEnclosures); recursive=true)
+include("init.jl")
 
 makedocs(
     sitename = "RangeEnclosures.jl",
@@ -8,7 +8,7 @@ makedocs(
     format = Documenter.HTML(
         prettyurls = get(ENV, "CI", nothing) == "true",
         assets = ["assets/aligned.css"]),
-    doctest = true,
+    doctest = false,
     strict = true,
     pages = [
         "Home" => "index.md",

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 AffineArithmetic = "2e89c364-fad6-56cb-99bd-ebadcd2cf8d2"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 IntervalOptimisation = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
 SDPA = "b9a10b5b-afa4-512f-a053-bb3d8080febc"
@@ -9,6 +10,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AffineArithmetic = "0.2"
+Documenter = "0.27"
 DynamicPolynomials = "0.3, 0.4"
 IntervalOptimisation = "0.4.1"
 SDPA = "0.2, 0.3, 0.4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,3 +7,7 @@ available_solvers = (NaturalEnclosure(), TaylorModelsEnclosure(), AffineArithmet
 
 include("univariate.jl")
 include("multivariate.jl")
+
+using Documenter
+include("../docs/init.jl")
+@time @testset "doctests" begin doctest(RangeEnclosures) end


### PR DESCRIPTION
This makes the docs build much more lightweight.