### PR TITLE
Remove IntervalBox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.2.1"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 ReachabilityBase = "379f33d0-9447-4353-bd03-d664070e549f"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ForwardDiff = "0.10"
 IntervalArithmetic = "0.15 - 0.21"
 ReachabilityBase = "0.1.1 - 0.2"
+RecipesBase = "0.6 - 0.8, 1"
 Requires = "0.5, 1"
 julia = "1.6"

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -66,8 +66,8 @@ As you can see, the result is much tighter now, while still being rigorous! The 
 using Plots
 plot(xlabel="x", ylabel="f(x)", legendfontsize=12, tickfontsize=12,
      xguidefont=font(15, "Times"), yguidefont=font(15, "Times"))
-plot!(IntervalBox(D, R), label="natural enclosure")
-plot!(IntervalBox(D, Rbb), label="branch and bound", alpha=1)
+plot!([D, R], label="natural enclosure")
+plot!([D, Rbb], label="branch and bound", alpha=1)
 plot!(f, -10, 10, lw=2, c=:black, label="f")
 ```
 
@@ -128,7 +128,7 @@ enclose(f, D, MooreSkelboeEnclosure())
 
 ### Bounding multivariate functions
 
-While our previous examples were in one dimension, the techniques generalize to multivariate functions ``\mathbb{R}^n\rightarrow\mathbb{R}``, the only difference is that the domain, instead of being an interval, should be an `IntervalBox`. For example, consider the function
+While our previous examples were in one dimension, the techniques generalize to multivariate functions ``\mathbb{R}^n\rightarrow\mathbb{R}``, the only difference is that the domain, instead of being an interval, should be an `AbstractVector` of `Interval`s. For example, consider the function
 
 ```math
 h(x_1, x_2) = \sin(x_1) - \cos(x_2) - \sin(x_1)\cos(x_1)
@@ -138,7 +138,7 @@ over the domain ``D_h = [-5, 5] \times [-5, 5]``. An enclosure can be computed a
 
 ```@example tutorial
 h(x) = sin(x[1]) - cos(x[2]) - sin(x[1]) * cos(x[1])
-Dh = IntervalBox(-5..5, -5..5)
+Dh = [-5..5, -5..5]
 Rh = enclose(h, Dh, BranchAndBoundEnclosure())
 ```
 

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -13,6 +13,7 @@ include("taylormodels.jl")
 include("affine.jl")
 include("sdp_header.jl")
 include("intervaloptimisation.jl")
+include("plot.jl")
 
 # ================
 # Optional methods

--- a/src/RangeEnclosures.jl
+++ b/src/RangeEnclosures.jl
@@ -3,7 +3,7 @@ module RangeEnclosures
 using Requires
 using ForwardDiff
 using IntervalArithmetic
-const Interval_or_IntervalBox = Union{Interval,IntervalBox}
+const Interval_or_IntervalVector = Union{Interval,AbstractVector{<:Interval}}
 using ReachabilityBase.Require
 
 include("algorithms.jl")
@@ -43,7 +43,6 @@ export enclose,
        BranchAndBoundEnclosure
 
 # standard ways from IntervalArithmetic to create intervals
-export interval, ..,
-       IntervalBox
+export interval, ..
 
 end  # module

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -17,9 +17,11 @@ function _enclose(::AffineArithmeticEnclosure, f::Function, dom::Interval)
 end
 
 # multivariate
-function _enclose(::AffineArithmeticEnclosure, f::Function, dom::IntervalBox{N}) where {N}
+function _enclose(::AffineArithmeticEnclosure, f::Function,
+                  dom::AbstractVector{<:Interval})
     require(@__MODULE__, :AffineArithmetic; fun_name="enclose")
 
+    N = length(dom)
     x = [Aff(dom[i], N, i) for i in 1:N]
     return interval(f(x))
 end

--- a/src/branchandbound.jl
+++ b/src/branchandbound.jl
@@ -5,12 +5,12 @@
 end
 
 # multivariate case
-@inline function enclose(f::Function, X::IntervalBox, ba::BranchAndBoundEnclosure;
-                         df=t -> ForwardDiff.gradient(f, t.v))
+@inline function enclose(f::Function, X::AbstractVector{<:Interval}, ba::BranchAndBoundEnclosure;
+                         df=t -> ForwardDiff.gradient(f, t))
     return _branch_bound(ba, f, X, df)
 end
 
-function _branch_bound(ba::BranchAndBoundEnclosure, f::Function, X::Interval_or_IntervalBox, df;
+function _branch_bound(ba::BranchAndBoundEnclosure, f::Function, X::Interval_or_IntervalVector, df;
                        initial=emptyinterval(first(X)),
                        cnt=1)
     dfX = df(X)
@@ -38,7 +38,9 @@ function _monotonicity_check(f::Function, X::Interval, dfX::Interval)
     return zero(eltype(dfX)), false
 end
 
-function _monotonicity_check(f::Function, X::IntervalBox{N}, ∇fX::AbstractVector) where {N}
+function _monotonicity_check(f::Function, X::AbstractVector{<:Interval},
+                             ∇fX::AbstractVector)
+    N = length(X)
     low = zeros(eltype(X), N)
     high = zeros(eltype(X), N)
 

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -8,7 +8,7 @@ domain.
 
 - `f`      -- function or `AbstractPolynomialLike` object
 - `dom`    -- hyperrectangular domain, either a unidimensional  `Interval` or
-              a multidimensional `IntervalBox`
+              a multidimensional vector of `Interval`s
 - `solver` -- (optional, default: `NaturalEnclosure()`) choose one among the
               available solvers; you can get a list of available solvers with
               `subtypes(AbstractEnclosureAlgorithm)`
@@ -38,12 +38,12 @@ julia> enclose(x -> 1 - x^4 + x^5, 0..1, [TaylorModelsEnclosure(), NaturalEnclos
 
 ```
 """
-function enclose(f::Function, dom::Interval_or_IntervalBox,
+function enclose(f::Function, dom::Interval_or_IntervalVector,
                  solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
     return _enclose(solver, f, dom; kwargs...)
 end
 
-function enclose(f::Function, dom::Interval_or_IntervalBox,
+function enclose(f::Function, dom::Interval_or_IntervalVector,
                  method::Vector; kwargs...)
     return mapreduce(ξ -> _enclose(ξ, f, dom; kwargs...), ∩, method)
 end

--- a/src/intervalarithmetic.jl
+++ b/src/intervalarithmetic.jl
@@ -2,7 +2,7 @@
 # Methods using interval arithmetic
 # =================================
 
-function _enclose(::NaturalEnclosure, f::Function, dom::Interval_or_IntervalBox; kwargs...)
+function _enclose(::NaturalEnclosure, f::Function, dom::Interval_or_IntervalVector; kwargs...)
     return f(dom)
 end
 
@@ -11,7 +11,7 @@ function _enclose(::MeanValueEnclosure, f::Function, dom::Interval;
     return f(mid(dom)) + df(dom) * (dom - mid(dom))
 end
 
-function _enclose(::MeanValueEnclosure, f::Function, dom::IntervalBox;
-                  df=t -> ForwardDiff.gradient(f, t.v))
+function _enclose(::MeanValueEnclosure, f::Function, dom::AbstractVector{<:Interval};
+                  df=t -> ForwardDiff.gradient(f, t))
     return f(mid.(dom)) + dot(df(dom), dom - mid.(dom))
 end

--- a/src/intervaloptimisation.jl
+++ b/src/intervaloptimisation.jl
@@ -2,7 +2,7 @@
 # Methods using interval optimization
 # ===================================
 
-function _enclose(mse::MooreSkelboeEnclosure, f::Function, dom::Interval_or_IntervalBox;
+function _enclose(mse::MooreSkelboeEnclosure, f::Function, dom::Interval_or_IntervalVector;
                   kwargs...)
     require(@__MODULE__, :IntervalOptimisation; fun_name="enclose")
 
@@ -14,8 +14,23 @@ end
 
 function load_intervaloptimization()
     return quote
+        import .IntervalOptimisation: numeric_type, diam
         using .IntervalOptimisation
 
         _default_vector_MSE = HeapedVector
+
+        numeric_type(X::AbstractVector{Interval{T}}) where {T} = T
+
+        diam(X::AbstractVector{<:Interval}) = maximum(diam.(X))
+
+        function IntervalArithmetic.bisect(X::AbstractVector{<:Interval})
+            i = argmax(diam.(X))  # find longest side
+            x1, x2 = bisect(X[i])
+            X1 = copy(X)
+            X1[i] = x1
+            X2 = copy(X)
+            X2[i] = x2
+            return (X1, X2)
+        end
     end  # quote
 end  # load_intervaloptimization()

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,0 +1,40 @@
+# adapted from
+# https://github.com/JuliaIntervals/IntervalArithmetic.jl/blob/v0.20.9/src/plot_recipes/plot_recipes.jl
+
+using RecipesBase
+
+@recipe function f(xx::AbstractVector{<:Interval})
+    @assert length(xx) == 2 "can only plot 2-dimensional interval boxes"
+
+    (x, y) = xx
+
+    seriesalpha --> 0.5
+    seriestype := :shape
+
+    x = [x.lo, x.hi, x.hi, x.lo]
+    y = [y.lo, y.lo, y.hi, y.hi]
+
+    x, y
+end
+
+@recipe function f(v::AbstractVector{<:AbstractVector{<:Interval}})
+
+    seriestype := :shape
+
+    xs = Float64[]
+    ys = Float64[]
+
+    for xx in v
+        @assert length(xx) == 2 "can only plot 2-dimensional interval boxes"
+        (x, y) = xx
+
+        # use NaNs to separate
+        append!(xs, [x.lo, x.hi, x.hi, x.lo, NaN])
+        append!(ys, [y.lo, y.lo, y.hi, y.hi, NaN])
+
+    end
+
+    seriesalpha --> 0.5
+
+    xs, ys
+end

--- a/src/polynomials.jl
+++ b/src/polynomials.jl
@@ -1,12 +1,12 @@
 using .MultivariatePolynomials
 
-function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalBox,
+function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalVector,
                  solver::AbstractEnclosureAlgorithm=NaturalEnclosure(); kwargs...)
     f(x) = p(x...)
     return _enclose(solver, f, dom; kwargs...)
 end
 
-function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalBox,
+function enclose(p::AbstractPolynomialLike, dom::Interval_or_IntervalVector,
                  solver::SumOfSquaresEnclosure; kwargs...)
     return _enclose(solver, p, dom; kwargs...)
 end

--- a/src/sdp.jl
+++ b/src/sdp.jl
@@ -1,7 +1,7 @@
 using .SumOfSquares
 
 function _enclose_sos(sose::SumOfSquaresEnclosure, p::AbstractPolynomialLike,
-                      dom::Interval_or_IntervalBox;
+                      dom::Interval_or_IntervalVector;
                       kwargs...)
     x = variables(p)
 

--- a/src/sdp_header.jl
+++ b/src/sdp_header.jl
@@ -2,7 +2,7 @@
 # Methods using semidefinite programming
 # ======================================
 
-function _enclose(sose::SumOfSquaresEnclosure, p, dom::Interval_or_IntervalBox;
+function _enclose(sose::SumOfSquaresEnclosure, p, dom::Interval_or_IntervalVector;
                   kwargs...)
     require(@__MODULE__, :SumOfSquares; fun_name="enclose")
 

--- a/test/multivariate.jl
+++ b/test/multivariate.jl
@@ -1,7 +1,7 @@
 @testset "Multivariate functions" begin
     # himmilbeau from Daisy benchmarks
     f(x) = -x[1] * x[2] - 2 * x[2] * x[3] - x[1] - x[3]
-    dom = interval(-4.5, -0.3) × interval(0.4, 0.9) × interval(3.8, 7.8)
+    dom = [interval(-4.5, -0.3), interval(0.4, 0.9), interval(3.8, 7.8)]
     xref = interval(-20.786552979420335, -0.540012836551535) # MOSEK deg 6
     for solver in available_solvers
         x = enclose(f, dom, solver)
@@ -16,7 +16,7 @@ end
 
 @testset "Multivariate example from the Quickstart Guide" begin
     g(x) = (x[1] + 2x[2] - 7)^2 + (2x[1] + x[2] - 5)^2
-    dom = IntervalBox(-10 .. 10, 2)
+    dom = [-10 .. 10, -10 .. 10]
 
     x = enclose(g, dom, NaturalEnclosure())
     xref = interval(0, 2594)
@@ -27,7 +27,7 @@ end
 @testset "Test multivariate polynomial input" begin
     @polyvar x y
     p = (x + 2y - 7)^2 + (2x + y - 5)^2
-    dom = IntervalBox(-10 .. 10, 2)
+    dom = [-10 .. 10, -10 .. 10]
 
     x = enclose(p, dom)
     xref = interval(-1446, 2594)
@@ -52,7 +52,7 @@ end
 
 @testset "Taylor-model solver without normalization" begin
     f(x) = x[1]^2 - 5x[1]
-    dom = IntervalBox(-1 .. 1, 0 .. 0)
+    dom = [-1 .. 1, 0 .. 0]
     x = enclose(f, dom, TaylorModelsEnclosure(; normalize=false))
     xref = interval(-4, 6)
     rleft, rright = relative_precision(x, xref)
@@ -61,7 +61,7 @@ end
 
 @testset "Test branch-and-bound solver" begin
     f(x) = (1 / 3)x[1]^3 + (x[1] - 0.5)^2
-    dom = IntervalBox(-4.0 .. 4.0, 0 .. 0)
+    dom = [-4.0 .. 4.0, 0 .. 0]
     xref = interval(-1.0833333333333321, 33.58333333333333)
     x = enclose(f, dom, BranchAndBoundEnclosure())
     rleft, rright = relative_precision(x, xref)


### PR DESCRIPTION
The first commit removes `IntervalBox` from the API to be ready for changes in upcoming `IntervalArithmetic` breaking changes. For `IntervalOptimisation` I had to define some methods. For `TaylorModels` I had to manually convert to `IntervalBox`. So the code actually still uses `IntervalBox` internally, but only with this optional dependency.

~~The second commit removes the `Interval` constructor (should have been done in #126, but since the tests use the old version, this was not detected... oops). This is independent of the other changes.~~

The ~~third~~ second commit adds a plot recipe for vectors of `Interval`s, which becomes necessary after removing `IntervalBox`.