### PR TITLE
Fix multivariate branch/bound for IntervalArithmetic v0.21

### DIFF
--- a/src/branchandbound.jl
+++ b/src/branchandbound.jl
@@ -44,11 +44,11 @@ function _monotonicity_check(f::Function, X::IntervalBox{N}, ∇fX::AbstractVect
 
     @inbounds for (i, di) in enumerate(∇fX)
         if di >= 0  #  increasing
-            high[i] = sup(X[i])
-            low[i] = inf(X[i])
+            high[i] = interval(sup(X[i]))
+            low[i] = interval(inf(X[i]))
         elseif di <= 0  # decreasing
-            high[i] = inf(X[i])
-            low[i] = sup(X[i])
+            high[i] = interval(inf(X[i]))
+            low[i] = interval(sup(X[i]))
         else
             return di, false
         end


### PR DESCRIPTION
This is not tested because our tests use `IntervalArithmetic` v0.20.9. But if you run the following example with v0.21, it crashes. The problem is an autoconversion to `Interval`, but the constructor was removed.

```julia
julia> using RangeEnclosures
julia> h(x) = sin(x[1]) - cos(x[2]) - sin(x[1]) * cos(x[1]);
julia> Dh = IntervalBox(-5 .. 5, -5 .. 5);
julia> enclose(h, Dh, BranchAndBoundEnclosure())
ERROR: MethodError: no method matching Interval{Float64}(::Float64)

Closest candidates are:
  (::Type{T})(::T) where T<:Number
   @ Core boot.jl:792
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number}
   @ Base char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number
   @ Base twiceprecision.jl:266
  ...

Stacktrace:
 [1] convert(#unused#::Type{Interval{Float64}}, x::Float64)
   @ Base ./number.jl:7
 [2] setindex!(A::Vector{Interval{Float64}}, x::Float64, i1::Int64)
   @ Base ./array.jl:969
 [3] _monotonicity_check(f::typeof(h), X::IntervalBox{2, Float64}, ∇fX::StaticArraysCore.SVector{2, Interval{Float64}})
   @ RangeEnclosures ~/.julia/dev/RangeEnclosures/src/branchandbound.jl:47
 [4] _branch_bound(ba::BranchAndBoundEnclosure, f::typeof(h), X::IntervalBox{2, Float64}, df::RangeEnclosures.var"#16#18"{typeof(h)}; initial::Interval{Float64}, cnt::Int64)
   @ RangeEnclosures ~/.julia/dev/RangeEnclosures/src/branchandbound.jl:17
 [5] _branch_bound(ba::BranchAndBoundEnclosure, f::Function, X::IntervalBox{2, Float64}, df::Function)
   @ RangeEnclosures ~/.julia/dev/RangeEnclosures/src/branchandbound.jl:13
 [6] #enclose#15
   @ ~/.julia/dev/RangeEnclosures/src/branchandbound.jl:10 [inlined]
 [7] enclose(f::Function, X::IntervalBox{2, Float64}, ba::BranchAndBoundEnclosure)
   @ RangeEnclosures ~/.julia/dev/RangeEnclosures/src/branchandbound.jl:8
 [8] top-level scope
   @ REPL[29]:1
```