### PR TITLE
Freeze IntervalArithmetic v0.20 in /docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,6 +6,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 Documenter = "1"
-IntervalArithmetic = "0.20"
+IntervalArithmetic = "^0.20"  # v0.21 requires updates and is incompatible with current dependencies
 IntervalOptimisation = "0.4"
 Plots = "1"


### PR DESCRIPTION
This is an attempt to prevent `CompatHelper` from bumping the version as in #141. `IntervalArithmetic` v0.21 would require changes to the docstrings, so this version should be mutually exclusive with v0.20. But currently, v0.21 is incompatible with many dependencies, so it cannot be used.