### PR TITLE
fix comparison to work with 0.21

### DIFF
--- a/src/branchandbound.jl
+++ b/src/branchandbound.jl
@@ -46,7 +46,7 @@ function _monotonicity_check(f::Function, X::IntervalBox{N}, ∇fX::AbstractVect
         if inf(di) >= 0  #  increasing
             high[i] = interval(sup(X[i]))
             low[i] = interval(inf(X[i]))
-        elseif sup(di) <=0  # decreasing
+        elseif sup(di) <= 0  # decreasing
             high[i] = interval(inf(X[i]))
             low[i] = interval(sup(X[i]))
         else

--- a/src/branchandbound.jl
+++ b/src/branchandbound.jl
@@ -43,10 +43,10 @@ function _monotonicity_check(f::Function, X::IntervalBox{N}, ∇fX::AbstractVect
     high = zeros(eltype(X), N)
 
     @inbounds for (i, di) in enumerate(∇fX)
-        if di >= 0  #  increasing
+        if inf(di) >= 0  #  increasing
             high[i] = interval(sup(X[i]))
             low[i] = interval(inf(X[i]))
-        elseif di <= 0  # decreasing
+        elseif sup(di) <=0  # decreasing
             high[i] = interval(inf(X[i]))
             low[i] = interval(sup(X[i]))
         else


### PR DESCRIPTION
now I get

```julia
(RangeEnclosures) pkg> st
Project RangeEnclosures v0.2.2
Status `~/.julia/dev/RangeEnclosures/Project.toml`
  [f6369f11] ForwardDiff v0.10.36
  [d1acc4aa] IntervalArithmetic v0.21.2
  [379f33d0] ReachabilityBase v0.2.0
  [ae029012] Requires v1.3.0

julia> h(x) = sin(x[1]) - cos(x[2]) - sin(x[1]) * cos(x[1])
h (generic function with 1 method)

julia> Dh = IntervalBox(-5 .. 5, -5 .. 5)
[-5.0, 5.0]²

julia> res = enclose(h, Dh, BranchAndBoundEnclosure())
[-2.71068, 2.71313]
```

fixes #149 