### PR TITLE
Freeze version of IntervalArithmetic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ForwardDiff = "0.10"
-IntervalArithmetic = "0.15 - 0.21"
+IntervalArithmetic = "0.15 - 0.21, =0.21.0"  # v0.21.1 removed IntervalBox
 ReachabilityBase = "0.1.1 - 0.2"
 Requires = "0.5, 1"
 julia = "1.6"


### PR DESCRIPTION
Closes #155.

`IntervalArithmetic` v0.21.1 removed `IntervalBox`. Since in #129 we decided to keep it, we have to upper-bound the version.