### PR TITLE
Follow-up of #156 Freeze version of IntervalArithmetic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ForwardDiff = "0.10"
-IntervalArithmetic = "0.15 - 0.21, =0.21.0"  # v0.21.1 removed IntervalBox
+IntervalArithmetic = "0.15 - 0.20, =0.21.0"  # v0.21.1 removed IntervalBox
 ReachabilityBase = "0.1.1 - 0.2"
 Requires = "0.5, 1"
 julia = "1.6"


### PR DESCRIPTION
I just realized that in #156 I should have removed `0.21` because that is interpreted as `0.21.*`.