### PR TITLE
Pass kwargs to default algorithm

### DIFF
--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -39,7 +39,7 @@ julia> enclose(x -> 1 - x^4 + x^5, 0..1, [TaylorModelsEnclosure(), NaturalEnclos
 ```
 """
 function enclose(f::Function, dom::Interval_or_IntervalBox; kwargs...)
-    return enclose(f, dom, NaturalEnclosure())
+    return enclose(f, dom, NaturalEnclosure(); kwargs...)
 end
 
 function enclose(f::Function, dom::Interval_or_IntervalBox,


### PR DESCRIPTION
The default algorithm ignores keyword arguments, but I still find it better to ignore them at the end of the pipeline.