### PR TITLE
Undo SDPA workaround

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -43,10 +43,6 @@ jobs:
         uses: julia-actions/cache@v2
       - name: Build package
         uses: julia-actions/julia-buildpkg@v1
-      - name: Fix SDPA to v0.5 in Julia v1.6
-        run: |
-          julia --project=. -e 'import Pkg;
-            if VERSION < v"1.7" Pkg.add(name="SDPA", version="0.5"); Pkg.pin(name="SDPA", version="0.5") end;'
       - name: Run tests
         uses: julia-actions/julia-runtest@v1
       - name: Process coverage

--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -2,10 +2,5 @@ using RangeEnclosures, Test
 import Aqua
 
 @testset "Aqua tests" begin
-    if VERSION >= v"1.7"
-        Aqua.test_all(RangeEnclosures)
-    else
-        # some tests fail in v1.6 due to problems in SDPA
-        Aqua.test_all(RangeEnclosures; stale_deps=false, deps_compat=false)
-    end
+    Aqua.test_all(RangeEnclosures)
 end


### PR DESCRIPTION
The workaround from #196 has become redundant because SDPA fixed the registry.