### PR TITLE
Run doctests when building docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,13 +1,23 @@
 [deps]
 DisplayAs = "0b91fe84-8a4c-11e9-3e1d-67c38462b6d6"
+AffineArithmetic = "2e89c364-fad6-56cb-99bd-ebadcd2cf8d2"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalOptimisation = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SDPA = "b9a10b5b-afa4-512f-a053-bb3d8080febc"
+SumOfSquares = "4b9e565b-77fc-50a5-a571-1244f986bda1"
+TaylorModels = "314ce334-5f6e-57ae-acf6-00b6e903104a"
 
 [compat]
+AffineArithmetic = "0.2"
 DisplayAs = "0.1"
 Documenter = "1"
+DynamicPolynomials = "0.3 - 0.5, =0.5"
 IntervalArithmetic = "=0.20.9"  # new versions require updates and are incompatible with dependencies
 IntervalOptimisation = "0.4"
 Plots = "1"
+SDPA = "0.2 - 0.6"
+SumOfSquares = "0.3.6 - 0.7"
+TaylorModels = "0.3 - 0.7"

--- a/docs/init.jl
+++ b/docs/init.jl
@@ -1,1 +1,0 @@
-DocMeta.setdocmeta!(RangeEnclosures, :DocTestSetup, :(using RangeEnclosures); recursive=true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,12 @@
 using Documenter, RangeEnclosures
+using IntervalOptimisation, SumOfSquares, SDPA, TaylorModels
 
-include("init.jl")
+DocMeta.setdocmeta!(RangeEnclosures, :DocTestSetup, :(using RangeEnclosures); recursive=true)
 
 makedocs(; sitename="RangeEnclosures.jl",
          modules=[RangeEnclosures],
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true",
                                 assets=["assets/aligned.css"]),
-         doctest=false,
          pagesonly=true,
          pages=["Home" => "index.md",
                 "Tutorial" => "tutorial.md",

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 AffineArithmetic = "2e89c364-fad6-56cb-99bd-ebadcd2cf8d2"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 IntervalOptimisation = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
 SDPA = "b9a10b5b-afa4-512f-a053-bb3d8080febc"
@@ -12,7 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 AffineArithmetic = "0.2"
 Aqua = "0.8.9"
-Documenter = "0.27, 1"
 # DynamicPolynomials v0.6 leads to conflict with PolyJuMP, which requires IntervalArithmetic v0.22
 DynamicPolynomials = "0.3 - 0.5, =0.5"
 IntervalOptimisation = "0.4.1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,11 +12,4 @@ available_solvers = (NaturalEnclosure(),
 include("univariate.jl")
 include("multivariate.jl")
 include("paper.jl")
-
-using Documenter
-include("../docs/init.jl")
-@testset "doctests" begin
-    doctest(RangeEnclosures)
-end
-
 include("Aqua.jl")


### PR DESCRIPTION
This PR is undoing #100.

I am actually not convinced that this is a good idea. But I would like to discuss what the right way is in general (run doctests with the docs or with the normal tests). Currently, we only run the doctests with the normal tests here and in ReachabilityAnalysis.

#### Consequences of this change

- The docs run becomes much heavier, as it needs to build all optional packages. (At least in this package; in other packages, we create code depending on whether these packages are loaded, so we need to load them anyway in the normal docs run).
- The test run gets a bit lighter, as Documenter is not built anymore and the doctests are not checked. The latter gain should be minimal, given that the test run has already built the optional packages and compiled the functions used in the doctests.
    - PkgEval runs the tests every 3 days, so making that faster has implications. I have a faint hope that this actually fixes the PkgEval problem (#200), although I have no indication why it should.
- Code coverage is only measured in the test run. So if a doctest uses code that is not used in other tests, it would only count toward the coverage in the test run.