### PR TITLE
Use `DocumenterCitations` for bibliography

### DIFF
--- a/benchmark/Daisy/daisy.jl
+++ b/benchmark/Daisy/daisy.jl
@@ -7,9 +7,7 @@
 SUITE["Daisy"] = BenchmarkGroup()
 RESULTS = SUITE["Daisy"]
 
-# The following domains are used throughout the tests in Tables 3-5 in
-# [1] Althoff, M., Grebenyuk, D., & Kochdumper, N. (2018). Implementation of Taylor models in CORA 2018.
-#     In Proc. of the 5th International Workshop on Applied Verification for Continuous and Hybrid Systems.
+# The following domains are used throughout the tests in [AlthoffGK18; Tables 3-5](@citet).
 a = Interval(-4.5, -0.3)
 b = Interval(0.4, 0.9)
 c = Interval(3.8, 7.8)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 DisplayAs = "0b91fe84-8a4c-11e9-3e1d-67c38462b6d6"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 IntervalOptimisation = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -8,6 +9,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 [compat]
 DisplayAs = "0.1"
 Documenter = "1"
+DocumenterCitations = "1.3"
 IntervalArithmetic = "=0.20.9"  # new versions require updates and are incompatible with dependencies
 IntervalOptimisation = "0.4"
 Plots = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,21 @@
-using Documenter, RangeEnclosures
+using Documenter, RangeEnclosures, DocumenterCitations
 
 include("init.jl")
+
+bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"); style=:alpha)
 
 makedocs(; sitename="RangeEnclosures.jl",
          modules=[RangeEnclosures],
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true",
-                                assets=["assets/aligned.css"]),
+                                assets=["assets/aligned.css", "assets/citations.css"]),
          doctest=false,
+         plugins=[bib],
          pagesonly=true,
          pages=["Home" => "index.md",
                 "Tutorial" => "tutorial.md",
                 "Library" => Any["Types" => "lib/types.md",
                                  "Methods" => "lib/methods.md"],
+                "Bibliography" => "bibliography.md",
                 "About" => "about.md"])
 
 deploydocs(; repo="github.com/JuliaReach/RangeEnclosures.jl.git",

--- a/docs/src/assets/citations.css
+++ b/docs/src/assets/citations.css
@@ -1,0 +1,17 @@
+.citation dl {
+  display: grid;
+  grid-template-columns: max-content auto; }
+.citation dt {
+  grid-column-start: 1; }
+.citation dd {
+  grid-column-start: 2;
+  margin-bottom: 0.75em; }
+.citation ul {
+ padding: 0 0 2.25em 0;
+ margin: 0;
+ list-style: none !important;}
+.citation ul li {
+ text-indent: -2.25em;
+ margin: 0.33em 0.5em 0.5em 2.25em;}
+.citation ol li {
+ padding-left:0.75em;}

--- a/docs/src/bibliography.md
+++ b/docs/src/bibliography.md
@@ -1,0 +1,4 @@
+# Bibliography
+
+```@bibliography
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,0 +1,18 @@
+@inproceedings{AlthoffGK18,
+  author       = {Matthias Althoff and
+                  Dmitry Grebenyuk and
+                  Niklas Kochdumper},
+  editor       = {Goran Frehse and
+                  Matthias Althoff and
+                  Sergiy Bogomolov and
+                  Taylor T. Johnson},
+  title        = {Implementation of Taylor models in {CORA} 2018},
+  booktitle    = {Applied Verification of Continuous and Hybrid Systems ({ARCH18})},
+  series       = {EPiC Series in Computing},
+  volume       = {54},
+  pages        = {145--173},
+  publisher    = {EasyChair},
+  year         = {2018},
+  url          = {https://doi.org/10.29007/zzc7},
+  doi          = {10.29007/ZZC7}
+}

--- a/src/enclose.jl
+++ b/src/enclose.jl
@@ -80,13 +80,7 @@ julia> relative_precision(x, xref)
 
 This function measures the relative precision of the result in a more informative
 way than taking the scalar overestimation because it evaluates the precision of
-the lower and the upper bounds separately (cf. Eq. (20) in [1]).
-
-[1] Althoff, Matthias, Dmitry Grebenyuk, and Niklas Kochdumper.
-   *Implementation of Taylor models in CORA 2018.*
-   Proc. of the 5th International Workshop on Applied Verification for
-   Continuous and Hybrid Systems. 2018.
-
+the lower and the upper bounds separately (cf. [AlthoffGK18; Eq. (20)](@citet)).
 """
 function relative_precision(x::Interval, xref::Interval)
     x⁻, x⁺ = inf(x), sup(x)


### PR DESCRIPTION
The updated documentation is [here](https://juliareach.github.io/RangeEnclosures.jl/previews/PR206/lib/methods/#RangeEnclosures.relative_precision).