### PR TITLE
Require higher version of IntervalArithmetic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ForwardDiff = "0.10, 1"
-IntervalArithmetic = "0.22"
+IntervalArithmetic = "0.22.12"
 IntervalBoxes = "0.2"
 LinearAlgebra = "<0.0.1, 1.6"
 ReachabilityBase = "0.1.1 - 0.3"


### PR DESCRIPTION
IntervalBoxes requires IntervalArithmetic v0.22.12. So this change just makes that requirement more explicit.